### PR TITLE
appveyor or github action CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,37 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: [x64, Win32]
+        
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: MSBuild of plugin dll
+      working-directory: .
+      run: msbuild RainLexer.sln /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+    - name: Archive artifacts for x64
+      if: matrix.build_platform == 'x64' && matrix.build_configuration == 'Release'
+      uses: actions/upload-artifact@v3
+      with:
+          name: plugin_dll_x64
+          path: x64-${{ matrix.build_configuration }}\RainLexer.dll
+
+    - name: Archive artifacts for Win32
+      if: matrix.build_platform == 'Win32' && matrix.build_configuration == 'Release'
+      uses: actions/upload-artifact@v3
+      with:
+          name: plugin_dll_x86
+          path: x32-${{ matrix.build_configuration }}\RainLexer.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,70 @@
+version: 2.19.0.{build}
+image: Visual Studio 2022
+
+
+environment:
+  matrix:
+  - PlatformToolset: v143
+
+platform:
+    - x64
+    - Win32
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x64" set platform_input=x64
+    - if "%platform%"=="Win32" set archi=x86
+    - if "%platform%"=="Win32" set platform_input=Win32
+    - call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild RainLexer.sln /m /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM_INPUT -eq "x64" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "x64-$env:CONFIGURATION\RainLexer.dll" -FileName RainLexer.dll
+        }
+
+        if ($env:PLATFORM_INPUT -eq "Win32" -and $env:CONFIGURATION -eq "Release") {
+            Push-AppveyorArtifact "x32-$env:CONFIGURATION\RainLexer.dll" -FileName RainLexer.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v143") {
+            if($env:PLATFORM_INPUT -eq "x64"){
+            $ZipFileName = "RainLexer_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            Remove-Item x64-$env:CONFIGURATION\*.ilk
+            Remove-Item x64-$env:CONFIGURATION\*.pdb
+            7z a $ZipFileName x64-$env:CONFIGURATION\*
+            }
+            if($env:PLATFORM_INPUT -eq "Win32"){
+            $ZipFileName = "RainLexer_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            Remove-Item x32-$env:CONFIGURATION\*.ilk
+            Remove-Item x32-$env:CONFIGURATION\*.pdb
+            7z a $ZipFileName x32-$env:CONFIGURATION\*
+            }
+        }
+
+artifacts:
+  - path: RainLexer_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v143
+        configuration: Release


### PR DESCRIPTION
- added appveyor.yml config for continous integration, see https://ci.appveyor.com/project/chcg/rainlexer/builds/44395976
- added github CI action
- could also be changed\extended to create the release files and automatically deploy to github
- creation of a zip file with the release would allow usage N++ builtin PluginAdmin https://github.com/notepad-plus-plus/nppPluginList
- automatically verification of pull request regarding build

@jsmorley  Is this PR or an update/changed one of interest for the project?